### PR TITLE
Metadata conversion moved to airflow

### DIFF
--- a/plugins/custom_operator/geonode.py
+++ b/plugins/custom_operator/geonode.py
@@ -115,8 +115,8 @@ class GeoNodeUploaderOperator(BaseOperator):
         client.get(f"http://{conn.host}:{conn.port}/api/v2/uploads/{upload_id}")
 
         time.sleep(self.call_delay)
-        self.log.info(f"Calling final upload page")
-        client.get(f"http://{conn.host}:{conn.port}/upload/final?id={import_id}")
+        #self.log.info(f"Calling final upload page")
+        #client.get(f"http://{conn.host}:{conn.port}/upload/final?id={import_id}")
 
         self.log.info(f"Layer added in GeoNode")
 

--- a/settings/variables.json
+++ b/settings/variables.json
@@ -3,6 +3,7 @@
     "WAITING_DELAY_IN_MINUTES": "3",
     "OPERATOR_MAX_RETRIES": "5",
     "DAG_CONCURRENCY": "16",
-    "MAX_ACTIVE_RUNS": "1"
+    "MAX_ACTIVE_RUNS": "1",
+    "OPTIONAL_METADATA": "['edition']"
 }
 


### PR DESCRIPTION
- Remove the unwanted check on the final detail page
- Add quoting of `HTML` tags in the georecify process
- add a function named `_is_required_field` to evaluate if the metadata field should be preset
- default variable value named `OPTIONAL_METADATA` to understand which contain a list of metadata keyword to ignore in the metadata validation in the georectify process (`default: ['edition']`)